### PR TITLE
Add consent, blocklist, blur, and tray capture controls

### DIFF
--- a/src/ScreenCaptureApp/AppConfig.cs
+++ b/src/ScreenCaptureApp/AppConfig.cs
@@ -1,0 +1,56 @@
+using System.Drawing;
+using System.Text.Json;
+
+namespace ScreenCaptureApp
+{
+    public class AppConfig
+    {
+        private const string ConfigFileName = "capture_config.json";
+
+        public bool ConsentAccepted { get; set; }
+
+        public string PrivacyPolicyUrl { get; set; } = "https://example.com/privacy";
+
+        public List<string> BlockedProcesses { get; set; } = new();
+
+        public List<BlurMask> BlurMasks { get; set; } = new();
+
+        public static string GetConfigPath()
+        {
+            var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ScreenCaptureApp");
+            Directory.CreateDirectory(folder);
+            return Path.Combine(folder, ConfigFileName);
+        }
+
+        public static AppConfig Load()
+        {
+            var path = GetConfigPath();
+            if (!File.Exists(path))
+            {
+                return new AppConfig();
+            }
+
+            var content = File.ReadAllText(path);
+            var config = JsonSerializer.Deserialize<AppConfig>(content);
+            return config ?? new AppConfig();
+        }
+
+        public void Save()
+        {
+            var path = GetConfigPath();
+            var content = JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(path, content);
+        }
+    }
+
+    public class BlurMask
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+        public int Width { get; set; }
+        public int Height { get; set; }
+        public double Sigma { get; set; } = 6.0;
+
+        public Rectangle ToRectangle() => new(X, Y, Width, Height);
+    }
+}

--- a/src/ScreenCaptureApp/CaptureService.cs
+++ b/src/ScreenCaptureApp/CaptureService.cs
@@ -1,0 +1,146 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using System.Linq;
+
+namespace ScreenCaptureApp
+{
+    public class CaptureService
+    {
+        private readonly AppConfig _config;
+        private readonly List<string> _normalizedBlockList;
+
+        public CaptureService(AppConfig config)
+        {
+            _config = config;
+            _normalizedBlockList = config.BlockedProcesses.Select(p => p.ToLowerInvariant()).ToList();
+        }
+
+        public bool ShouldCaptureCurrentWindow()
+        {
+            var foreground = NativeMethods.GetForegroundWindow();
+            if (foreground == IntPtr.Zero)
+            {
+                return true;
+            }
+
+            _ = NativeMethods.GetWindowThreadProcessId(foreground, out var pid);
+            try
+            {
+                var process = System.Diagnostics.Process.GetProcessById((int)pid);
+                var name = process.ProcessName.ToLowerInvariant();
+                return !_normalizedBlockList.Contains(name);
+            }
+            catch
+            {
+                return true;
+            }
+        }
+
+        public Bitmap CaptureScreen()
+        {
+            var primary = Screen.PrimaryScreen ?? throw new InvalidOperationException("No screens detected");
+            var bounds = primary.Bounds;
+            var bitmap = new Bitmap(bounds.Width, bounds.Height, PixelFormat.Format32bppArgb);
+            using var graphics = Graphics.FromImage(bitmap);
+            graphics.CopyFromScreen(bounds.Location, Point.Empty, bounds.Size);
+            ApplyBlurMasks(bitmap, _config.BlurMasks);
+            return bitmap;
+        }
+
+        private static void ApplyBlurMasks(Bitmap bitmap, IEnumerable<BlurMask> masks)
+        {
+            foreach (var mask in masks)
+            {
+                var rectangle = mask.ToRectangle();
+                using var region = bitmap.Clone(rectangle, bitmap.PixelFormat);
+                var blurred = ApplyGaussianBlur(region, mask.Sigma);
+                using var graphics = Graphics.FromImage(bitmap);
+                graphics.DrawImage(blurred, rectangle.Location);
+            }
+        }
+
+        private static Bitmap ApplyGaussianBlur(Bitmap source, double sigma)
+        {
+            var radius = (int)Math.Ceiling(sigma * 3);
+            var size = radius * 2 + 1;
+            var kernel = BuildKernel(size, sigma);
+            var blurred = new Bitmap(source.Width, source.Height);
+
+            for (int y = 0; y < source.Height; y++)
+            {
+                for (int x = 0; x < source.Width; x++)
+                {
+                    double r = 0, g = 0, b = 0, a = 0, weightSum = 0;
+                    for (int ky = -radius; ky <= radius; ky++)
+                    {
+                        for (int kx = -radius; kx <= radius; kx++)
+                        {
+                            int sampleX = Math.Clamp(x + kx, 0, source.Width - 1);
+                            int sampleY = Math.Clamp(y + ky, 0, source.Height - 1);
+                            var weight = kernel[ky + radius, kx + radius];
+                            var pixel = source.GetPixel(sampleX, sampleY);
+                            r += pixel.R * weight;
+                            g += pixel.G * weight;
+                            b += pixel.B * weight;
+                            a += pixel.A * weight;
+                            weightSum += weight;
+                        }
+                    }
+
+                    if (weightSum > 0)
+                    {
+                        r /= weightSum;
+                        g /= weightSum;
+                        b /= weightSum;
+                        a /= weightSum;
+                    }
+
+                    var color = Color.FromArgb((int)a.Clamp(0, 255), (int)r.Clamp(0, 255), (int)g.Clamp(0, 255), (int)b.Clamp(0, 255));
+                    blurred.SetPixel(x, y, color);
+                }
+            }
+
+            return blurred;
+        }
+
+        private static double[,] BuildKernel(int size, double sigma)
+        {
+            var kernel = new double[size, size];
+            int radius = size / 2;
+            double twoSigmaSquared = 2 * sigma * sigma;
+            double normalization = 1.0 / (Math.PI * twoSigmaSquared);
+
+            for (int y = -radius; y <= radius; y++)
+            {
+                for (int x = -radius; x <= radius; x++)
+                {
+                    double exponent = -((x * x + y * y) / twoSigmaSquared);
+                    kernel[y + radius, x + radius] = normalization * Math.Exp(exponent);
+                }
+            }
+
+            return kernel;
+        }
+    }
+
+    internal static class NativeMethods
+    {
+        [DllImport("user32.dll")]
+        public static extern IntPtr GetForegroundWindow();
+
+        [DllImport("user32.dll")]
+        public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+    }
+
+    internal static class NumericExtensions
+    {
+        public static double Clamp(this double value, double min, double max)
+        {
+            if (value < min) return min;
+            if (value > max) return max;
+            return value;
+        }
+    }
+}

--- a/src/ScreenCaptureApp/FirstRunDialog.cs
+++ b/src/ScreenCaptureApp/FirstRunDialog.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics;
+using System.Windows.Forms;
+
+namespace ScreenCaptureApp
+{
+    public static class FirstRunDialog
+    {
+        public static bool EnsureConsent(AppConfig config)
+        {
+            if (config.ConsentAccepted)
+            {
+                return true;
+            }
+
+            var message = "Screen capture requires your consent. Please review the privacy terms before continuing.";
+            var result = MessageBox.Show(message, "Privacy and Consent", MessageBoxButtons.OKCancel, MessageBoxIcon.Information, MessageBoxDefaultButton.Button1, MessageBoxOptions.DefaultDesktopOnly, false);
+
+            if (result == DialogResult.OK)
+            {
+                ShowPrivacyPolicy(config.PrivacyPolicyUrl);
+                var confirm = MessageBox.Show("Do you accept the privacy terms and consent to capture?", "Confirm consent", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                if (confirm == DialogResult.Yes)
+                {
+                    config.ConsentAccepted = true;
+                    config.Save();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void ShowPrivacyPolicy(string url)
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = url,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Unable to open privacy policy: {ex.Message}");
+            }
+        }
+    }
+}

--- a/src/ScreenCaptureApp/Program.cs
+++ b/src/ScreenCaptureApp/Program.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Windows.Forms;
+
+namespace ScreenCaptureApp
+{
+    internal static class Program
+    {
+        [STAThread]
+        private static void Main()
+        {
+            ApplicationConfiguration.Initialize();
+            var config = AppConfig.Load();
+            if (!FirstRunDialog.EnsureConsent(config))
+            {
+                return;
+            }
+
+            using var captureService = new CaptureService(config);
+            using var tray = new TrayController(captureService);
+            tray.Start();
+            Application.Run();
+        }
+    }
+}

--- a/src/ScreenCaptureApp/ScreenCaptureApp.csproj
+++ b/src/ScreenCaptureApp/ScreenCaptureApp.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/ScreenCaptureApp/TrayController.cs
+++ b/src/ScreenCaptureApp/TrayController.cs
@@ -1,0 +1,81 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace ScreenCaptureApp
+{
+    public class TrayController : IDisposable
+    {
+        private readonly NotifyIcon _trayIcon;
+        private readonly CaptureService _captureService;
+        private readonly Timer _captureTimer;
+        private bool _paused;
+
+        public TrayController(CaptureService captureService)
+        {
+            _captureService = captureService;
+            _trayIcon = BuildTrayIcon();
+            _captureTimer = new Timer { Interval = 2000 };
+            _captureTimer.Tick += (_, _) => OnCaptureTick();
+        }
+
+        public void Start()
+        {
+            _paused = false;
+            UpdateIndicator();
+            _captureTimer.Start();
+        }
+
+        private void OnCaptureTick()
+        {
+            if (_paused)
+            {
+                return;
+            }
+
+            if (!_captureService.ShouldCaptureCurrentWindow())
+            {
+                _trayIcon.Text = "Capturing (skipped)";
+                return;
+            }
+
+            using var bitmap = _captureService.CaptureScreen();
+            // Encoding to disk or network would happen here.
+            _trayIcon.Text = "Capturing";
+        }
+
+        private NotifyIcon BuildTrayIcon()
+        {
+            var contextMenu = new ContextMenuStrip();
+            var pauseResume = new ToolStripMenuItem("Pause") { CheckOnClick = false };
+            pauseResume.Click += (_, _) => TogglePause(pauseResume);
+            contextMenu.Items.Add(pauseResume);
+            contextMenu.Items.Add(new ToolStripMenuItem("Exit", null, (_, _) => Application.Exit()));
+
+            return new NotifyIcon
+            {
+                Icon = SystemIcons.Information,
+                Text = "Capturing",
+                Visible = true,
+                ContextMenuStrip = contextMenu
+            };
+        }
+
+        private void TogglePause(ToolStripMenuItem toggleItem)
+        {
+            _paused = !_paused;
+            toggleItem.Text = _paused ? "Resume" : "Pause";
+            UpdateIndicator();
+        }
+
+        private void UpdateIndicator()
+        {
+            _trayIcon.Text = _paused ? "Capture paused" : "Capturing";
+        }
+
+        public void Dispose()
+        {
+            _captureTimer.Dispose();
+            _trayIcon.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add first-run consent dialog with privacy policy link and persisted acceptance
- enforce foreground process blocklist before taking captures and support tray pause/resume indicator
- support configurable blur masks with Gaussian blur applied before encoding

## Testing
- not run (not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947fb948fac832988f1af37ee80cc02)