### PR TITLE
Add capture service with graphics capture and fallback

### DIFF
--- a/ScreenCapture/Capture/CaptureService.cs
+++ b/ScreenCapture/Capture/CaptureService.cs
@@ -1,0 +1,220 @@
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Graphics.Capture;
+using Windows.Graphics.DirectX.Direct3D11;
+using Windows.Graphics.Imaging;
+using Windows.Storage.Streams;
+
+namespace ScreenCapture.Capture;
+
+public sealed class CaptureService : IAsyncDisposable
+{
+    private readonly TimeSpan _defaultInterval = TimeSpan.FromSeconds(1);
+    private readonly object _syncRoot = new();
+    private IDirect3DDevice? _direct3DDevice;
+    private Direct3D11CaptureFramePool? _framePool;
+    private GraphicsCaptureSession? _session;
+    private GraphicsCaptureItem? _captureItem;
+    private SizeInt32 _lastSize;
+
+    public bool IsGraphicsCaptureAvailable => GraphicsCaptureSession.IsSupported();
+
+    public async Task<IRandomAccessStream?> CaptureOnceAsync(CancellationToken cancellationToken = default)
+    {
+        if (IsGraphicsCaptureAvailable)
+        {
+            await EnsureCaptureSessionAsync(cancellationToken).ConfigureAwait(false);
+            return await CaptureCurrentFrameAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return await CaptureWithBitBltAsync().ConfigureAwait(false);
+    }
+
+    public async Task StartContinuousCaptureAsync(
+        Func<IRandomAccessStream, Task> frameHandler,
+        TimeSpan? interval = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (frameHandler is null)
+        {
+            throw new ArgumentNullException(nameof(frameHandler));
+        }
+
+        var delay = interval ?? _defaultInterval;
+
+        if (IsGraphicsCaptureAvailable)
+        {
+            await EnsureCaptureSessionAsync(cancellationToken).ConfigureAwait(false);
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var stream = await CaptureCurrentFrameAsync(cancellationToken).ConfigureAwait(false);
+                if (stream != null)
+                {
+                    await frameHandler(stream).ConfigureAwait(false);
+                }
+
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var stream = await CaptureWithBitBltAsync().ConfigureAwait(false);
+                if (stream != null)
+                {
+                    await frameHandler(stream).ConfigureAwait(false);
+                }
+
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Task.Yield();
+        lock (_syncRoot)
+        {
+            _session?.Dispose();
+            _framePool?.Dispose();
+            _session = null;
+            _framePool = null;
+            _captureItem = null;
+        }
+    }
+
+    private async Task EnsureCaptureSessionAsync(CancellationToken cancellationToken)
+    {
+        if (_session != null && _captureItem != null)
+        {
+            return;
+        }
+
+        var picker = new GraphicsCapturePicker();
+        _captureItem = await picker.PickSingleItemAsync().AsTask(cancellationToken).ConfigureAwait(false);
+        if (_captureItem == null)
+        {
+            throw new InvalidOperationException("No capture target selected.");
+        }
+
+        _direct3DDevice ??= Direct3D11Helper.CreateDevice();
+        _lastSize = _captureItem.Size;
+        _framePool = Direct3D11CaptureFramePool.Create(
+            _direct3DDevice,
+            Windows.Graphics.DirectX.DirectXPixelFormat.B8G8R8A8UIntNormalized,
+            1,
+            _lastSize);
+
+        _session = _framePool.CreateCaptureSession(_captureItem);
+        _session.StartCapture();
+    }
+
+    private async Task<IRandomAccessStream?> CaptureCurrentFrameAsync(CancellationToken cancellationToken)
+    {
+        if (_framePool == null)
+        {
+            return null;
+        }
+
+        var tcs = new TaskCompletionSource<IRandomAccessStream?>();
+        void OnFrameArrived(Direct3D11CaptureFramePool sender, object args)
+        {
+            try
+            {
+                using var frame = sender.TryGetNextFrame();
+                if (frame == null)
+                {
+                    tcs.TrySetResult(null);
+                    return;
+                }
+
+                if (frame.ContentSize.Width != _lastSize.Width || frame.ContentSize.Height != _lastSize.Height)
+                {
+                    ResizeFramePool(frame.ContentSize);
+                }
+
+                var bitmap = SoftwareBitmap.CreateCopyFromSurfaceAsync(frame.Surface).AsTask().Result;
+                var stream = new InMemoryRandomAccessStream();
+                var encoder = BitmapEncoder.CreateAsync(BitmapEncoder.JpegEncoderId, stream).AsTask().Result;
+                encoder.SetSoftwareBitmap(bitmap);
+                encoder.IsThumbnailGenerated = false;
+                encoder.FlushAsync().AsTask().Wait();
+                stream.Seek(0);
+                tcs.TrySetResult(stream);
+            }
+            catch (Exception ex)
+            {
+                tcs.TrySetException(ex);
+            }
+            finally
+            {
+                sender.FrameArrived -= OnFrameArrived;
+            }
+        }
+
+        _framePool.FrameArrived += OnFrameArrived;
+        using var registration = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+        return await tcs.Task.ConfigureAwait(false);
+    }
+
+    private void ResizeFramePool(SizeInt32 newSize)
+    {
+        if (_framePool == null || _captureItem == null || _direct3DDevice == null)
+        {
+            return;
+        }
+
+        _framePool.Recreate(
+            _direct3DDevice,
+            Windows.Graphics.DirectX.DirectXPixelFormat.B8G8R8A8UIntNormalized,
+            1,
+            newSize);
+        _lastSize = newSize;
+    }
+
+    private Task<IRandomAccessStream?> CaptureWithBitBltAsync()
+    {
+        var screenDc = Gdi32.GetDC(IntPtr.Zero);
+        try
+        {
+            var width = Gdi32.GetSystemMetrics(Gdi32.SystemMetric.SM_CXSCREEN);
+            var height = Gdi32.GetSystemMetrics(Gdi32.SystemMetric.SM_CYSCREEN);
+            var compatibleDc = Gdi32.CreateCompatibleDC(screenDc);
+            var bitmap = Gdi32.CreateCompatibleBitmap(screenDc, width, height);
+            var old = Gdi32.SelectObject(compatibleDc, bitmap);
+
+            _ = Gdi32.BitBlt(
+                compatibleDc,
+                0,
+                0,
+                width,
+                height,
+                screenDc,
+                0,
+                0,
+                Gdi32.TernaryRasterOperations.SRCCOPY | Gdi32.TernaryRasterOperations.CAPTUREBLT);
+
+            using var image = System.Drawing.Image.FromHbitmap(bitmap);
+            using var memory = new MemoryStream();
+            image.Save(memory, System.Drawing.Imaging.ImageFormat.Jpeg);
+            memory.Position = 0;
+
+            var randomAccessStream = new InMemoryRandomAccessStream();
+            randomAccessStream.WriteAsync(memory.GetWindowsRuntimeBuffer()).AsTask().Wait();
+            randomAccessStream.Seek(0);
+
+            Gdi32.SelectObject(compatibleDc, old);
+            Gdi32.DeleteObject(bitmap);
+            Gdi32.DeleteDC(compatibleDc);
+            return Task.FromResult<IRandomAccessStream?>(randomAccessStream);
+        }
+        finally
+        {
+            Gdi32.ReleaseDC(IntPtr.Zero, screenDc);
+        }
+    }
+}

--- a/ScreenCapture/Capture/Direct3D11Helper.cs
+++ b/ScreenCapture/Capture/Direct3D11Helper.cs
@@ -1,0 +1,91 @@
+using System.Runtime.InteropServices;
+using Windows.Graphics.DirectX.Direct3D11;
+
+namespace ScreenCapture.Capture;
+
+internal static class Direct3D11Helper
+{
+    private const string D3D11 = "d3d11.dll";
+
+    public static IDirect3DDevice CreateDevice()
+    {
+        var devicePtr = CreateD3DDevice();
+        var dxgiGuid = typeof(IDXGIDevice).GUID;
+        Marshal.ThrowExceptionForHR(Marshal.QueryInterface(devicePtr, ref dxgiGuid, out var dxgiPtr));
+
+        try
+        {
+            var dxgiDevice = Marshal.GetObjectForIUnknown(dxgiPtr);
+            Marshal.ThrowExceptionForHR(CreateDirect3D11DeviceFromDXGIDevice(dxgiDevice!, out var graphicsDevice));
+            return graphicsDevice;
+        }
+        finally
+        {
+            Marshal.Release(dxgiPtr);
+            Marshal.Release(devicePtr);
+        }
+    }
+
+    private static IntPtr CreateD3DDevice()
+    {
+        var flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+        var featureLevels = new[]
+        {
+            D3D_FEATURE_LEVEL_11_1,
+            D3D_FEATURE_LEVEL_11_0,
+            D3D_FEATURE_LEVEL_10_1,
+            D3D_FEATURE_LEVEL_10_0,
+        };
+
+        Marshal.ThrowExceptionForHR(D3D11CreateDevice(
+            IntPtr.Zero,
+            D3D_DRIVER_TYPE_HARDWARE,
+            IntPtr.Zero,
+            flags,
+            featureLevels,
+            featureLevels.Length,
+            D3D11_SDK_VERSION,
+            out var device,
+            out _,
+            out var context));
+
+        if (context != IntPtr.Zero)
+        {
+            Marshal.Release(context);
+        }
+
+        return device;
+    }
+
+    [DllImport(D3D11, ExactSpelling = true)]
+    private static extern int D3D11CreateDevice(
+        IntPtr pAdapter,
+        int driverType,
+        IntPtr software,
+        int flags,
+        [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)] uint[] pFeatureLevels,
+        int featureLevels,
+        uint sdkVersion,
+        out IntPtr ppDevice,
+        out IntPtr pFeatureLevel,
+        out IntPtr ppImmediateContext);
+
+    [DllImport(D3D11, EntryPoint = "CreateDirect3D11DeviceFromDXGIDevice", SetLastError = true)]
+    private static extern int CreateDirect3D11DeviceFromDXGIDevice(
+        [MarshalAs(UnmanagedType.IUnknown)] object dxgiDevice,
+        out IDirect3DDevice graphicsDevice);
+
+    [ComImport, Guid("77db970f-6276-48ba-ba28-070143b4392c"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IDXGIDevice
+    {
+    }
+
+    private const int D3D_DRIVER_TYPE_HARDWARE = 1;
+    private const int D3D11_CREATE_DEVICE_BGRA_SUPPORT = 0x20;
+    private const uint D3D11_SDK_VERSION = 7;
+
+    private const uint D3D_FEATURE_LEVEL_10_0 = 0xb000;
+    private const uint D3D_FEATURE_LEVEL_10_1 = 0xb100;
+    private const uint D3D_FEATURE_LEVEL_11_0 = 0xb0000;
+    private const uint D3D_FEATURE_LEVEL_11_1 = 0xb1000;
+}

--- a/ScreenCapture/Capture/Gdi32.cs
+++ b/ScreenCapture/Capture/Gdi32.cs
@@ -1,0 +1,55 @@
+using System.Runtime.InteropServices;
+
+namespace ScreenCapture.Capture;
+
+internal static class Gdi32
+{
+    [Flags]
+    public enum TernaryRasterOperations : uint
+    {
+        SRCCOPY = 0x00CC0020,
+        CAPTUREBLT = 0x40000000,
+    }
+
+    public enum SystemMetric
+    {
+        SM_CXSCREEN = 0,
+        SM_CYSCREEN = 1,
+    }
+
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetDC(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
+
+    [DllImport("user32.dll")]
+    public static extern int GetSystemMetrics(SystemMetric nIndex);
+
+    [DllImport("gdi32.dll")]
+    public static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    public static extern bool DeleteDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    public static extern IntPtr CreateCompatibleBitmap(IntPtr hdc, int nWidth, int nHeight);
+
+    [DllImport("gdi32.dll")]
+    public static extern bool DeleteObject(IntPtr hObject);
+
+    [DllImport("gdi32.dll")]
+    public static extern IntPtr SelectObject(IntPtr hdc, IntPtr hObject);
+
+    [DllImport("gdi32.dll")]
+    public static extern bool BitBlt(
+        IntPtr hdcDest,
+        int nXDest,
+        int nYDest,
+        int nWidth,
+        int nHeight,
+        IntPtr hdcSrc,
+        int nXSrc,
+        int nYSrc,
+        TernaryRasterOperations dwRop);
+}

--- a/ScreenCapture/ScreenCapture.csproj
+++ b/ScreenCapture/ScreenCapture.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.22621.2428" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a Windows capture service that selects a target via GraphicsCapturePicker and outputs JPEG streams
- support one-off captures and continuous timer-driven capture loops using Direct3D11 frame pooling
- include BitBlt-based fallback for environments without Graphics Capture support

## Testing
- not run (dotnet tooling unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947fb928d508329a32cfdc37f56429c)