### PR TITLE
Add health endpoint for server status

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -21,6 +21,13 @@ const client = new OpenAIClient({
 const app = express();
 app.use(express.static(path.join(__dirname, '..', 'public')));
 
+app.get('/health', (_req, res) => {
+  res.json({
+    status: 'ok',
+    rateLimitPerMinute: client.rateLimiter?.requestsPerMinute || null,
+  });
+});
+
 app.post('/api/describe', upload.single('image'), async (req, res) => {
   const prompt = req.body?.prompt || 'Describe the image';
   const imageBuffer = req.file?.buffer;


### PR DESCRIPTION
## Summary
- add a simple /health endpoint to expose server status and rate limit configuration
- keep existing static file serving and image description flow unchanged

## Testing
- npm start

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694801d780a083299aef3228c6391b70)